### PR TITLE
Allow for empty tells to be matched

### DIFF
--- a/OpenParser/Filters/CompiledRegex.cs
+++ b/OpenParser/Filters/CompiledRegex.cs
@@ -8,7 +8,7 @@ namespace OpenParser.Filters
 
     public static class CompiledRegex
     {
-        public static Regex TellRegex { get; } = new Regex(@"\A(.+?) (told|tells) (\w*?)(,?) '(.+)'$",
+        public static Regex TellRegex { get; } = new Regex(@"\A(.+?) (told|tells) (\w*?)(,?) '(.*)'$",
             RegexOptions.Compiled);
 
         public static Regex SayRegex { get; } = new Regex(@"\A(.+?) (say|says)(,?) '(.+)'$", RegexOptions.Compiled);

--- a/OpenParser/Properties/AssemblyInfo.cs
+++ b/OpenParser/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]


### PR DESCRIPTION
EverQuest allows empty tells to be sent.  This should successfully match them.  Addresses Issue #2  that I submitted.